### PR TITLE
corrected use of parameter

### DIFF
--- a/node/startNewDialog/index.js
+++ b/node/startNewDialog/index.js
@@ -33,7 +33,7 @@ bot.dialog('/survey', [
 function startProactiveDialog(addr) {
   // set resume:false to resume at the root dialog
   // else true to resume the previous dialog
-  bot.beginDialog(savedAddress, "*:/survey", {}, { resume: true });  
+  bot.beginDialog(addr, "*:/survey", {}, { resume: true });  
 }
 
 var savedAddress;


### PR DESCRIPTION
Looks like the author meant to use the addr parameter instead of global variable savedAddress.
Doesn't affect functionality of sample as it stands - but worth fixing up.